### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -1,7 +1,20 @@
 cmake_minimum_required(VERSION 3.2.5)
 
-include_directories(../)
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -g -O2 -pthread")
+set(CMAKE_CXX_STANDARD 11 Required)
+project(test_interface LANGUAGES CXX)
 
-add_executable( test_steady_pond_interface test_steady_pond_interface.cpp)
-add_executable( test_dynamic_pond_interface test_dynamic_pond_interface.cpp)
+IF(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+ENDIF()
+
+find_package(Threads REQUIRED)
+
+# target: test_steady_pond_interface
+add_executable(test_steady_pond_interface test_steady_pond_interface.cpp)
+target_include_directories(test_steady_pond_interface PUBLIC ../)
+target_link_libraries(test_steady_pond_interface PUBLIC Threads::Threads)
+
+# target: test_dynamic_pond_interface
+add_executable(test_dynamic_pond_interface test_dynamic_pond_interface.cpp)
+target_include_directories(test_dynamic_pond_interface PUBLIC ../)
+target_link_libraries(test_dynamic_pond_interface PUBLIC Threads::Threads)


### PR DESCRIPTION
现代cmake可以很方便地管理项目, 此处我小小地规范了CMakeList, 原来的并不跨平台.
另外: 
1. 切换优化开关可以通过CMake插件选择或命令行 `-DCMAKE_BUILD_TYPE=...`;
2. 两个源文件中的 include 可以换为位置无关的 `#include <hipe.h>`, vscode 有波浪线的话build一次就会消失
3. 推荐可以倍速直接看小彭老师视频: `https://www.bilibili.com/video/BV16P4y1g7MH/` 和 `https://www.bilibili.com/video/BV1V84y117YU/`